### PR TITLE
Joseph form & Time varying filter

### DIFF
--- a/FUNCTIONS.rst
+++ b/FUNCTIONS.rst
@@ -21,6 +21,7 @@ In order to reduce code size, some features can be disabled by globally defining
 :KALMAN_DISABLE_UC:         Disable filter functions for systems without control input. Set this if all your systems use control input or if you use certainty tuning.
 :KALMAN_DISABLE_C:          Disable filter functions for systems with control inputs. Set this if none of your systems use control input.
 :KALMAN_DISABLE_LAMBDA:     Disable filter functions with certainty tuning (lambda parameter). Set this if you do not need to control filter convergence speed.
+:KALMAN_JOSEPH_FORM:        Enable the Joseph form of the covariance update equation. Set this if Kalman gain is non-optimal or your filter has problems with numerical stability. Please be aware that this form of the covariance update equation is computationally more expensive. Set this definition in settings.h.
 
 Definitions
 ===========

--- a/FUNCTIONS.rst
+++ b/FUNCTIONS.rst
@@ -22,6 +22,7 @@ In order to reduce code size, some features can be disabled by globally defining
 :KALMAN_DISABLE_C:          Disable filter functions for systems with control inputs. Set this if none of your systems use control input.
 :KALMAN_DISABLE_LAMBDA:     Disable filter functions with certainty tuning (lambda parameter). Set this if you do not need to control filter convergence speed.
 :KALMAN_JOSEPH_FORM:        Enable the Joseph form of the covariance update equation. Set this if Kalman gain is non-optimal or your filter has problems with numerical stability. Please be aware that this form of the covariance update equation is computationally more expensive. Set this definition in settings.h.
+:KALMAN_TIME_VARYING:       Enable time-varying Kalman filter for Kalman filter with control input. In this case the square system process noise matrix is replaced by the  square contol input covariance matrix and the covariance prediction step changes from ``P = A*P*A' + Q`` to ``P = A*P*A' + B*Q*B'``. Set this definition in settings.h.
 
 Definitions
 ===========
@@ -39,7 +40,8 @@ Data structure for the filter state. ::
         mf16 P; // S x S
         mf16 u; // C x 1
         mf16 B; // S x C
-        mf16 Q; // C x C
+        mf16 Q; // C x C    if KALMAN_TIME_VARYING is defined
+        mf16 Q; // S x S    if KALMAN_TIME_VARYING is not defined
     } kalman16_t;
 
 :x:         System state vector. Number of rows in the vector, 1 <= rows <= FIXMATRIX_MAX_SIZE.
@@ -47,7 +49,8 @@ Data structure for the filter state. ::
 :P:         Square system state covariance matrix. Number of rows and columns is identical to ``A``.
 :u:         Input vector. Number of rows in the vector, 1 <= rows <= FIXMATRIX_MAX_SIZE.
 :B:         Control input model matrix. Number of rows in the matrix is equal to the number of rows in the state vector ``x``. Number of columns in the matrix is equal to the number of rows in the input vector ``u``.
-:Q:         Square contol input covariance matrix. Number of rows and columns in the matrix is equal to the number of rows in the input vector ``u``.
+:Q:         Square contol input covariance matrix. Number of rows and columns in the matrix is equal to the number of rows in the input vector ``u``. (if KALMAN_TIME_VARYING is defined)
+:Q:         Square system process noise matrix. Number of rows and columns is identical to ``A``. (if KALMAN_TIME_VARYING is not defined)
 
 The filter structure can be initialized by calling
 

--- a/fixkalman.c
+++ b/fixkalman.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 
 #include "fixarray.h"
+#include "settings.h"
 
 #define EXTERN_INLINE_KALMAN INLINE
 #include "fixkalman.h"

--- a/settings.h
+++ b/settings.h
@@ -1,0 +1,14 @@
+// Settings header for libfixkalman
+
+#ifndef _SETTINGS_H_
+#define _SETTINGS_H_
+
+/* ----------------------------------------------------------------------- */
+/* Replace of the covariance update equation with the Joseph form.         */
+/* Set this if Kalman gain is non-optimal or your filter has problems with */ 
+/* numerical stability. Please be aware that this form of the covariance   */
+/* update equation is computationally more expensive.                      */
+/* ----------------------------------------------------------------------- */
+#define KALMAN_JOSEPH_FORM
+
+#endif

--- a/settings.h
+++ b/settings.h
@@ -9,6 +9,21 @@
 /* numerical stability. Please be aware that this form of the covariance   */
 /* update equation is computationally more expensive.                      */
 /* ----------------------------------------------------------------------- */
-#define KALMAN_JOSEPH_FORM
+//#define KALMAN_JOSEPH_FORM
+
+/* ----------------------------------------------------------------------- */
+/* Transforms the square system process noise matrix into square contol    */
+/* input covariance matrix for Kalman filter with control input.           */
+/*                                                                         */
+/* The square system process noise matrix has as many of rows and columns  */
+/* as the matrix A.                                                        */
+/* In this case the covariance prediction step looks like: P = A*P*A' + Q  */
+/*                                                                         */
+/* By the square contol input covariance matrix the number of rows and     */
+/* columns are equal to the number of rows in the input vector u.          */
+/* In this case the covariance prediction step looks like:                 */
+/* P = A*P*A' + B*Q*B'                                                     */  
+/* ----------------------------------------------------------------------- */
+//#define KALMAN_TIME_VARYING
 
 #endif


### PR DESCRIPTION
Hi,

so I did some other modifications in your library.

These are just some switching possibilities for some equations. Unfortunately I did not manage to handle the definitions in the external project files so I needed to define a settings.h file.

First because of the fix16 computation it might happen that the implemented Kalman filter gets numerically unstable. To overcome this problem I implemented the possibility to switch to the Joseph form of the covariance update equations. With this rounding error cannot happen in the computation.

The other stuff is a little bit more complicated. This is only relevant for Kalman filters with control input. Actually what you implemented there is a special case of the Kalman filter called the Time-Varying Kalman Filter. 
Standard covariance prediction equation: P(t+1) = A_P(t)_A' + Q
Same for the Time-Varying Kalman Filter: P(t+1) = A_P(t)_A' + B_Q_B'
The Time-Varying Kalman Filter is very good if you have members in the B matrix which are heavily effected by the time between two prediction. If this time is not constant you are able to redefine your B matrix and take the effects into account. Or if your Q matrix is somehow not constant you can do modifications.
To show you the problem with it let me write here a small example. Assume that we have a body with a mass of m = 1 kg. To keep it simple lets do this only in 1D. Our control vector u is just a simple force F which we apply on the system. In this case our system matrices are:
x = [ position,
        velocity,
        acceleration ]
A =  [ 1, t, 0,
        0, 1, 0,
        0, 0, 0 ]
B = [ t^2/(2*m),
           t/m,
          1/m  ]

t is the elapsed time between two prediction steps. As you have a 3x1 matrix for B, you will have a 1x1 matrix for Q. You can set it to a value c.
Now if we calculate B_Q_B' we will get the following:
B_Q_B' = [ (t^4/(4_m^2))_c,        0,              0,
                      0,             (t^2/m^2)_c,        0,
                      0,                       0,        (1/m^2)_c ]

Let's assume that we can measure the position with 0.01 m accuracy. And we call the predictor in every 0.2 seconds. 

You can see that the predictor will have a very small number in the diagonal for the position and a normal one for the acceleration depending on the value of c. So for the position the prediction will have absolute dominance and the sensor value will not be taken into consideration. This is a problem because we have a very good accuracy but we are not able to tell the Kalman filter, that yes take this.

Additionally we perform an additional B_Q_B' calculation in every step which is absolutely not needed if our values are constants. 

That is why I would suppress the P(t+1) = A_P(t)_A' + B_Q_B' calculation and treat it as a possible feature and I would take P(t+1) = A_P(t)_A' + Q for standard calculation.

It might of course happen that I got something wrong from the theory. If this is the case please let me know it.
